### PR TITLE
Crc decoding redesign boardside

### DIFF
--- a/software_package/in4073/drivers/packet.c
+++ b/software_package/in4073/drivers/packet.c
@@ -3,9 +3,17 @@
  *
  *  Author: Niket Agrawal, Jonathan Levy
  * 
+ * CRC is computed byte by byte and CRC check is done at the end of each packet (13 bytes) as before. 
+ * The idea is to NOT discard the whole packet upon CRC decoding failure, as we may have picked a wrong start byte 
+ * and assumed that a new packet has started. If we throw the packet, we may loose the correct start byte which could 
+ * be somewhere within the packet.
+ * if a CRC check failure is detected, the next start byte is found starting from the previous start byte.
+ * If a start byte (0xFF) is detected within the current packet, this means we re-use a chunk of this packet. 
+ * New packet starts from this new start byte. All the bytes before this are discarded
+ * CRC is computed for the left over bytes first (from new start byte to end of packet). 
+ * Rest half of the packet is formed by new bytes arriving to process packet method and CRC is computed in usual manner.
  *
- *
- *  April 2018
+ *  May 2018
  *------------------------------------------------------------------
  */
 

--- a/software_package/in4073/drivers/packet.c
+++ b/software_package/in4073/drivers/packet.c
@@ -124,6 +124,7 @@ void process_packet(uint8_t c) {
             printf("Next start byte found at %d\n", l);
             #endif
 
+            //if next start byte was found within the current packet
             if(l < CONTROL_PACKET_SIZE)
             {
                 #ifdef DEBUGCRC
@@ -137,8 +138,10 @@ void process_packet(uint8_t c) {
                     crc = crc ^ packet[i];
                     index = index + 1;
                 }
-                //packet_length = l + CONTROL_PACKET_SIZE;  //reset packet length for full packet traversal
-                //printf("New packet length is %d\n", packet_length);
+                //CRC computation done for the 1st half of the packet, new bytes arriving
+                //to prpcess_packet method will form the 2nd half of this packet and CRC 
+                //computation will continue from (index < size) check in line 59
+                
             }
 
             else //no other start byte found in the current packet
@@ -155,7 +158,9 @@ void process_packet(uint8_t c) {
         
     }
 
-    // reset index to zero and clear packet if index reached the end of packet
+    // reset index to zero and clear packet if index reached the end of packet,
+    // this is required for case when there is no CRC error and a full packet is
+    // parsed and decoded correctly
     if(index == CONTROL_PACKET_SIZE)
     {
         index = 0;

--- a/software_package/in4073/pc_terminal/joystick.c
+++ b/software_package/in4073/pc_terminal/joystick.c
@@ -16,12 +16,18 @@ void JoystickData_destroy(JoystickData *jsdata)
 	free(jsdata);
 }
 
-void js_init(int *fd, char *path_to_joystick)
+void js_init(int *fd, char *path_to_joystick, struct js_event *js)
 {
 	if ((*fd = open(path_to_joystick, O_RDONLY)) < 0) {
 		perror("jserroropen");
 		exit(1);
 	}
+	
+	js->time = 0;
+	js->value = 0;
+	js->type = 0;
+	js->number = 0;
+
 	fcntl(*fd, F_SETFL, O_NONBLOCK);
 }
 
@@ -40,7 +46,7 @@ void js_getJoystickValue(int *fd, struct js_event *js, JoystickData *jsdat)
 					jsdat->button[js->number] = js->value;
 					break;
 				case JS_EVENT_AXIS:
-					fprintf(stderr, "reading joystick\n");
+					//fprintf(stderr, "reading joystick\n");
 					jsdat->axis[js->number] = js->value;
 					break;
 			}

--- a/software_package/in4073/pc_terminal/joystick.h
+++ b/software_package/in4073/pc_terminal/joystick.h
@@ -47,8 +47,8 @@
 #define JS_EVENT_INIT		0x80	/* initial state of device */
 
 struct js_event {
-	__u32 time;	/* event timestamp in milliseconds */
-	__s16 value;	/* value */
+	__u32 time ;	/* event timestamp in milliseconds */
+	__s16 value ;	/* value */
 	__u8 type;	/* event type */
 	__u8 number;	/* axis/button number */
 };
@@ -133,14 +133,14 @@ struct JS_DATA_SAVE_TYPE {
 
 
 struct joystickData {
-	u_int16_t	axis[NBRAXES];
-	u_int8_t 	button[NBRBUTTONS];
+	u_int16_t	axis[NBRAXES] ;
+	u_int8_t 	button[NBRBUTTONS] ;
 };
 
 typedef struct joystickData JoystickData;
 
 		
-void js_init(int *fd, char *path_to_joystick);
+void js_init(int *fd, char *path_to_joystick, struct js_event *js);
 void js_getJoystickValue(int *fd, struct js_event *js, JoystickData *jsdat);
 JoystickData *JoystickData_create();
 void JoystickData_destroy(JoystickData *jsdata);

--- a/software_package/in4073/pc_terminal/pc_terminal.c
+++ b/software_package/in4073/pc_terminal/pc_terminal.c
@@ -333,7 +333,7 @@ int main(int argc, char **argv)
 	char isContinuing = 1;
 
 
-	js_init(&fd, path_to_joystick);
+	js_init(&fd, path_to_joystick, &js);
 	JoystickData *jsdat = JoystickData_create();
 
 	struct timespec tp;
@@ -358,6 +358,8 @@ int main(int argc, char **argv)
 		{
 			control_packet[AXISTHROTTLE + 2*j] = MSBYTE( jsdat->axis[j] );
 			control_packet[AXISTHROTTLE + 2*j + 1] = LSBYTE( jsdat->axis[j] );
+			//control_packet[AXISTHROTTLE + 2*j] = 0xFF;
+			//control_packet[AXISTHROTTLE + 2*j + 1] = 0xFF;
 		}
 		for (int j = 0; j < NBRBUTTONS; j++)
 		{
@@ -370,8 +372,10 @@ int main(int argc, char **argv)
 				isContinuing = 0;
 			else if ((d >= 48) && (d <= 56))
 				control_packet[MODE] = d;
+				//control_packet[MODE] = 0xFF;
 			else 
 				control_packet[KEY] = d;
+				//control_packet[KEY] = 0xFF;
 		}
 		
 
@@ -388,7 +392,7 @@ int main(int argc, char **argv)
 		fprintf(stderr, "clk=%ld,%ld\n",tp.tv_sec, tp.tv_nsec);
 		#endif
 		
-		//
+		
 		if (tp.tv_nsec - tic >= DELAY_PACKET_NS || tp.tv_sec - tic_s > 0)
 		{
 			tic = tp.tv_nsec;


### PR DESCRIPTION
Logic for packet parsing on the board side:
- CRC is computed byte by byte and CRC check is done at the end of each packet (13 bytes) as before. 
- The idea is to NOT discard the whole packet upon CRC decoding failure, as we may have picked a wrong start byte and assumed that a new packet has started. If we throw the whole packet, we may loose the correct start byte which could be somewhere within the packet.
- if a CRC check failure is detected, the next start byte is found starting from the previous start byte.
- If a start byte (0xFF) is detected within the current packet, this means we re-use a chunk of this packet. - New packet starts from this new start byte. All the bytes before this are discarded
- CRC is computed for the left over bytes first (from new start byte to end of packet). 
- Rest half of the packet is formed by new bytes arriving to process packet method and CRC is computed in usual manner.

  