### PR TITLE
Speedup pc terminal - 2 processes (fork)

### DIFF
--- a/software_package/in4073/pc_terminal/pc_terminal.c
+++ b/software_package/in4073/pc_terminal/pc_terminal.c
@@ -518,92 +518,85 @@ int main(int argc, char **argv)
 	
 	if (process_1)
 	{
-		pid_t process_2 = fork();
-		if (process_2)
+		while (isContinuing)
 		{
-			while (isContinuing)
+			// Response time is a bit variable. Latency can be percieved still.
+
+			// poll axes with raw-OS method
+			js_getJoystickValue(&fd, &js, jsdat);
+			for (int j = 0; j < NBRAXES; j++)
 			{
-				clock_gettime(CLOCK_REALTIME, &tp);
-				
-				#ifdef DEBUGCLK
-				fprintf(stderr, "clk=%ld,%ld\n",tp.tv_sec, tp.tv_nsec);
-				#endif
-				
-				if (tp.tv_nsec - tic >= DELAY_PACKET_NS || tp.tv_sec - tic_s > 0)
-				{
-					tic = tp.tv_nsec;
-					tic_s = tp.tv_sec;
-					send_packet();
-				}
+				control_packet[AXISROLL + 2*j] = MSBYTE( jsdat->axis[j] );
+				control_packet[AXISROLL + 2*j + 1] = LSBYTE( jsdat->axis[j] );
+				//control_packet[AXISTHROTTLE + 2*j] = 0xFF;
+				//control_packet[AXISTHROTTLE + 2*j + 1] = 0xFF;
 			}
-		} else {
-			while (isContinuing)
+			for (int j = 0; j < NBRBUTTONS; j++)
 			{
-				// Response time is a bit variable. Latency can be percieved still.
-
-				// poll axes with raw-OS method
-				js_getJoystickValue(&fd, &js, jsdat);
-				for (int j = 0; j < NBRAXES; j++)
+				control_packet[JOYBUTTON] |= (jsdat->button[j] == 1) << j; // 10 for not storing anything.
+			}
+			
+			if ((d = term_getchar_nb()) != -1)
+			{
+				// Logic to read arrow key presses
+				// Source: https://ubuntuforums.org/showthread.php?t=2276177
+				if (d == 27) //escape key
 				{
-					control_packet[AXISROLL + 2*j] = MSBYTE( jsdat->axis[j] );
-					control_packet[AXISROLL + 2*j + 1] = LSBYTE( jsdat->axis[j] );
-					//control_packet[AXISTHROTTLE + 2*j] = 0xFF;
-					//control_packet[AXISTHROTTLE + 2*j + 1] = 0xFF;
-				}
-				for (int j = 0; j < NBRBUTTONS; j++)
-				{
-					control_packet[JOYBUTTON] |= (jsdat->button[j] == 1) << j; // 10 for not storing anything.
-				}
-				
-				if ((d = term_getchar_nb()) != -1)
-				{
-					// Logic to read arrow key presses
-					// Source: https://ubuntuforums.org/showthread.php?t=2276177
-					if (d == 27) //escape key
+					y = getchar();
+					z = getchar();
+					printf("Key code y is %d\n", y);
+					printf("Key code z is %d\n", z);
+					if (d == 27 && y == 91)
 					{
-						y = getchar();
-						z = getchar();
-						printf("Key code y is %d\n", y);
-						printf("Key code z is %d\n", z);
-						if (d == 27 && y == 91)
+						switch (z)
 						{
-							switch (z)
-							{
-							case 65:
-							printf("up arrow key pressed\n");
-							control_packet[KEY] = 42;
-							break;
+						case 65:
+						printf("up arrow key pressed\n");
+						control_packet[KEY] = 42;
+						break;
 
-							case 66:
-							printf("down arrow key pressed\n");
-							control_packet[KEY] = 44;
-							break;
+						case 66:
+						printf("down arrow key pressed\n");
+						control_packet[KEY] = 44;
+						break;
 
-							case 67:
-							printf("right arrow key pressed\n");
-							control_packet[KEY] = 43;
-							break;
+						case 67:
+						printf("right arrow key pressed\n");
+						control_packet[KEY] = 43;
+						break;
 
-							case 68:
-							printf("left arrow key pressed\n");
-							control_packet[KEY] = 45;
-							break;
-							}
+						case 68:
+						printf("left arrow key pressed\n");
+						control_packet[KEY] = 45;
+						break;
 						}
-						else 
-						isContinuing = 0;
 					}
-					else if ((d >= '0') && (d <= '8'))
-						control_packet[MODE] = d;
-						//control_packet[MODE] = 0xFF;
 					else 
-						control_packet[KEY] = d;
-						//control_packet[KEY] = 0xFF;
+					isContinuing = 0;
 				}
+				else if ((d >= 48) && (d <= 56))
+					control_packet[MODE] = d;
+					//control_packet[MODE] = 0xFF;
+				else 
+					control_packet[KEY] = d;
+					//control_packet[KEY] = 0xFF;
+			}
+
+			clock_gettime(CLOCK_REALTIME, &tp);
+			
+			#ifdef DEBUGCLK
+			fprintf(stderr, "clk=%ld,%ld\n",tp.tv_sec, tp.tv_nsec);
+			#endif
+			
+			if (tp.tv_nsec - tic >= DELAY_PACKET_NS || tp.tv_sec - tic_s > 0)
+			{
+				tic = tp.tv_nsec;
+				tic_s = tp.tv_sec;
+				send_packet();
 			}
 		}
 	} else {
-		while (isContinuing)
+		while (1)
 		{
 			if ((rs232_getchar_nb(&c)) != -1)
 			{

--- a/software_package/in4073/pc_terminal/pc_terminal.c
+++ b/software_package/in4073/pc_terminal/pc_terminal.c
@@ -518,85 +518,92 @@ int main(int argc, char **argv)
 	
 	if (process_1)
 	{
-		while (isContinuing)
+		pid_t process_2 = fork();
+		if (process_2)
 		{
-			// Response time is a bit variable. Latency can be percieved still.
-
-			// poll axes with raw-OS method
-			js_getJoystickValue(&fd, &js, jsdat);
-			for (int j = 0; j < NBRAXES; j++)
+			while (isContinuing)
 			{
-				control_packet[AXISROLL + 2*j] = MSBYTE( jsdat->axis[j] );
-				control_packet[AXISROLL + 2*j + 1] = LSBYTE( jsdat->axis[j] );
-				//control_packet[AXISTHROTTLE + 2*j] = 0xFF;
-				//control_packet[AXISTHROTTLE + 2*j + 1] = 0xFF;
-			}
-			for (int j = 0; j < NBRBUTTONS; j++)
-			{
-				control_packet[JOYBUTTON] |= (jsdat->button[j] == 1) << j; // 10 for not storing anything.
-			}
-			
-			if ((d = term_getchar_nb()) != -1)
-			{
-				// Logic to read arrow key presses
-				// Source: https://ubuntuforums.org/showthread.php?t=2276177
-				if (d == 27) //escape key
+				clock_gettime(CLOCK_REALTIME, &tp);
+				
+				#ifdef DEBUGCLK
+				fprintf(stderr, "clk=%ld,%ld\n",tp.tv_sec, tp.tv_nsec);
+				#endif
+				
+				if (tp.tv_nsec - tic >= DELAY_PACKET_NS || tp.tv_sec - tic_s > 0)
 				{
-					y = getchar();
-					z = getchar();
-					printf("Key code y is %d\n", y);
-					printf("Key code z is %d\n", z);
-					if (d == 27 && y == 91)
-					{
-						switch (z)
-						{
-						case 65:
-						printf("up arrow key pressed\n");
-						control_packet[KEY] = 42;
-						break;
-
-						case 66:
-						printf("down arrow key pressed\n");
-						control_packet[KEY] = 44;
-						break;
-
-						case 67:
-						printf("right arrow key pressed\n");
-						control_packet[KEY] = 43;
-						break;
-
-						case 68:
-						printf("left arrow key pressed\n");
-						control_packet[KEY] = 45;
-						break;
-						}
-					}
-					else 
-					isContinuing = 0;
+					tic = tp.tv_nsec;
+					tic_s = tp.tv_sec;
+					send_packet();
 				}
-				else if ((d >= 48) && (d <= 56))
-					control_packet[MODE] = d;
-					//control_packet[MODE] = 0xFF;
-				else 
-					control_packet[KEY] = d;
-					//control_packet[KEY] = 0xFF;
 			}
-
-			clock_gettime(CLOCK_REALTIME, &tp);
-			
-			#ifdef DEBUGCLK
-			fprintf(stderr, "clk=%ld,%ld\n",tp.tv_sec, tp.tv_nsec);
-			#endif
-			
-			if (tp.tv_nsec - tic >= DELAY_PACKET_NS || tp.tv_sec - tic_s > 0)
+		} else {
+			while (isContinuing)
 			{
-				tic = tp.tv_nsec;
-				tic_s = tp.tv_sec;
-				send_packet();
+				// Response time is a bit variable. Latency can be percieved still.
+
+				// poll axes with raw-OS method
+				js_getJoystickValue(&fd, &js, jsdat);
+				for (int j = 0; j < NBRAXES; j++)
+				{
+					control_packet[AXISROLL + 2*j] = MSBYTE( jsdat->axis[j] );
+					control_packet[AXISROLL + 2*j + 1] = LSBYTE( jsdat->axis[j] );
+					//control_packet[AXISTHROTTLE + 2*j] = 0xFF;
+					//control_packet[AXISTHROTTLE + 2*j + 1] = 0xFF;
+				}
+				for (int j = 0; j < NBRBUTTONS; j++)
+				{
+					control_packet[JOYBUTTON] |= (jsdat->button[j] == 1) << j; // 10 for not storing anything.
+				}
+				
+				if ((d = term_getchar_nb()) != -1)
+				{
+					// Logic to read arrow key presses
+					// Source: https://ubuntuforums.org/showthread.php?t=2276177
+					if (d == 27) //escape key
+					{
+						y = getchar();
+						z = getchar();
+						printf("Key code y is %d\n", y);
+						printf("Key code z is %d\n", z);
+						if (d == 27 && y == 91)
+						{
+							switch (z)
+							{
+							case 65:
+							printf("up arrow key pressed\n");
+							control_packet[KEY] = 42;
+							break;
+
+							case 66:
+							printf("down arrow key pressed\n");
+							control_packet[KEY] = 44;
+							break;
+
+							case 67:
+							printf("right arrow key pressed\n");
+							control_packet[KEY] = 43;
+							break;
+
+							case 68:
+							printf("left arrow key pressed\n");
+							control_packet[KEY] = 45;
+							break;
+							}
+						}
+						else 
+						isContinuing = 0;
+					}
+					else if ((d >= '0') && (d <= '8'))
+						control_packet[MODE] = d;
+						//control_packet[MODE] = 0xFF;
+					else 
+						control_packet[KEY] = d;
+						//control_packet[KEY] = 0xFF;
+				}
 			}
 		}
 	} else {
-		while (1)
+		while (isContinuing)
 		{
 			if ((rs232_getchar_nb(&c)) != -1)
 			{


### PR DESCRIPTION
I re-did the fork. It's ugly, but it works. We can consider going with a more elegant, robust, and future-proof solution afterwards, with pthreads.

Currently, no information is shared between the two processes. This means that if we read the mode in process 0 and store it in a global variable, it will be global only to process 0, and won't be read by process 1. Having shared memory will solve the issue but at the cost of implementing something to create mutual exclusion. But we can try this in the future. For the moment, this brutal "fork" seems to work fine, so let's keep it that way.