### PR TITLE
Modify p value keyboard

### DIFF
--- a/software_package/in4073/in4073.c
+++ b/software_package/in4073/in4073.c
@@ -44,6 +44,13 @@ void store_joystick_axis(uint8_t *val)
 		int16_t stickvalue = (((int16_t) *(val + 2*i)) << 8) + ((int16_t) *(val + 2*i + 1));
 		axis[i] = stickvalue;
 	}
+	if(axis[3] == 32767)
+	{
+		for(int i =0; i<3; i++)
+        {
+            offset[i] = 0;
+        }
+	}		
 }
 
 void store_joystick_button(uint8_t *val)
@@ -61,28 +68,29 @@ void store_key(uint8_t *val)
 		case 'j': proportional_controller_yaw = (proportional_controller_yaw > P_SCALING ? proportional_controller_yaw-P_SCALING : 1);
 			      break;
 
-		case 'a': offset[LIFT] = offset[LIFT] + OFFSET_SCALING; //lift up
+		case 'a': offset[LIFT] += OFFSET_SCALING; //lift up
 				  break;
 
-		case 'z': offset[LIFT] = (offset[LIFT] > OFFSET_SCALING ? offset[LIFT] - OFFSET_SCALING : 0); //lift down
+		case 'z': offset[LIFT] -= OFFSET_SCALING;
+					//offset[LIFT] = (offset[LIFT] > OFFSET_SCALING ? offset[LIFT] - OFFSET_SCALING : 0); //lift down
 				  break;	
 
-		case 44:  offset[PITCH] = offset[PITCH] + OFFSET_SCALING; //pitch up
+		case 44:  offset[PITCH] += OFFSET_SCALING; //pitch up
 				  break;
 
-		case 42:  offset[PITCH] = (offset[PITCH] > OFFSET_SCALING ? offset[PITCH] - OFFSET_SCALING : 0); //pitch down
+		case 42:  offset[PITCH] -= OFFSET_SCALING ; //pitch down
 				  break;
 
-		case 45:  offset[ROLL] = offset[ROLL] + OFFSET_SCALING; //roll up
+		case 43:  offset[ROLL] += OFFSET_SCALING; //roll down
 				  break;
 
-		case 43:  offset[ROLL] = (offset[ROLL] > OFFSET_SCALING ? offset[ROLL] - OFFSET_SCALING : 0); //roll down
+		case 45:  offset[ROLL] -= OFFSET_SCALING ; //roll up
 				  break;
 
-		case 'w': offset[YAW] = offset[YAW] + OFFSET_SCALING; //yaw up
+		case 'w': offset[YAW] += OFFSET_SCALING; //yaw up
 				  break; 
 
-		case 'q': offset[YAW] = (offset[YAW] > OFFSET_SCALING ? offset[YAW] - OFFSET_SCALING : 0); //yaw down
+		case 'q': offset[YAW] -= OFFSET_SCALING ; //yaw down
 				  break;	
 
 	}

--- a/software_package/in4073/in4073.c
+++ b/software_package/in4073/in4073.c
@@ -44,9 +44,11 @@ void store_joystick_axis(uint8_t *val)
 		int16_t stickvalue = (((int16_t) *(val + 2*i)) << 8) + ((int16_t) *(val + 2*i + 1));
 		axis[i] = stickvalue;
 	}
-	if(axis[3] == 32767)
+	
+	//If throttle is almost zero, clear the offset
+	if(axis[3] > 32000)
 	{
-		for(int i =0; i<3; i++)
+		for(int i =0; i<4; i++)
         {
             offset[i] = 0;
         }
@@ -263,8 +265,8 @@ int main(void)
 			clear_timer_flag();
 		}
 
-		if (nextmode != mode)
-			switch_mode(nextmode);
+		// if (nextmode != mode)
+		// 	switch_mode(nextmode); //commenting this additional code which possible got pasted twice in master
 
 
 		// Note: this is probably something that will be included in the mode functions.

--- a/software_package/in4073/in4073.c
+++ b/software_package/in4073/in4073.c
@@ -58,6 +58,13 @@ void store_joystick_axis(uint8_t *val)
 void store_joystick_button(uint8_t *val)
 {
 	buttons = *val;
+	//Enter panic mode if joystick fire button (Abort mission) pressed
+	if(buttons == 1)
+	{
+		abort_mission = 1;
+		nextmode = 1;
+	}
+		
 }
 
 void store_key(uint8_t *val)

--- a/software_package/in4073/in4073.c
+++ b/software_package/in4073/in4073.c
@@ -54,25 +54,39 @@ void store_joystick_button(uint8_t *val)
 void store_key(uint8_t *val)
 {
 	keyboard_key = *val;
-	// switch(keyboard_key)
-	// {
-	// 	case 97: offset[LIFT] = offset[LIFT] + 10; //lift up
-	// 			 break;
-	// 	case 122: offset[LIFT] = offset[LIFT] - 10; //lift down
-	// 			 break;
-	// 	case 42: offset[PITCH] = offset[PITCH] - 10; //pitch down
-	// 			 break;
-	// 	case 43: offset[LIFT] = offset[ROLL] - 10; //roll down
-	// 			 break;
-	// 	case 44: offset[LIFT] = offset[PITCH] + 10; //pitch up
-	// 			 break;
-	// 	case 45: offset[PITCH] = offset[ROLL] + 10; //roll up
-	// 			 break;
-	// 	case 113: offset[YAW] = offset[YAW] - 10; //yaw down
-	// 			 break;
-	// 	case 119: offset[YAW] = offset[YAW] + 10; //yaw up
-	// 			 break; 
-	// }
+	switch(keyboard_key)
+	{
+		case 'u': proportional_controller_yaw += P_SCALING;
+				  break;
+		case 'j': proportional_controller_yaw = (proportional_controller_yaw > P_SCALING ? proportional_controller_yaw-P_SCALING : 1);
+			      break;
+
+		case 'a': offset[LIFT] = offset[LIFT] + OFFSET_SCALING; //lift up
+				  break;
+
+		case 'z': offset[LIFT] = (offset[LIFT] > OFFSET_SCALING ? offset[LIFT] - OFFSET_SCALING : 0); //lift down
+				  break;	
+
+		case 44:  offset[PITCH] = offset[PITCH] + OFFSET_SCALING; //pitch up
+				  break;
+
+		case 42:  offset[PITCH] = (offset[PITCH] > OFFSET_SCALING ? offset[PITCH] - OFFSET_SCALING : 0); //pitch down
+				  break;
+
+		case 45:  offset[ROLL] = offset[ROLL] + OFFSET_SCALING; //roll up
+				  break;
+
+		case 43:  offset[ROLL] = (offset[ROLL] > OFFSET_SCALING ? offset[ROLL] - OFFSET_SCALING : 0); //roll down
+				  break;
+
+		case 'w': offset[YAW] = offset[YAW] + OFFSET_SCALING; //yaw up
+				  break; 
+
+		case 'q': offset[YAW] = (offset[YAW] > OFFSET_SCALING ? offset[YAW] - OFFSET_SCALING : 0); //yaw down
+				  break;	
+
+	}
+	telemetry_packet[P_VALUE] = proportional_controller_yaw;
 }
 
 void store_mode(uint8_t *val)

--- a/software_package/in4073/in4073.h
+++ b/software_package/in4073/in4073.h
@@ -176,7 +176,7 @@ uint8_t abort_mission;
 // Processing offset from Keyboard 
 #define OFFSET_SCALING 1
 
-#define P_SCALING 5
+#define P_SCALING 1
 
 uint8_t proportional_controller_yaw;
 bool is_calibration_done;

--- a/software_package/in4073/in4073.h
+++ b/software_package/in4073/in4073.h
@@ -174,7 +174,7 @@ uint8_t comm_link_failure;
 uint8_t abort_mission;
 
 // Processing offset from Keyboard 
-#define OFFSET_SCALING 10
+#define OFFSET_SCALING 1
 
 #define P_SCALING 5
 

--- a/software_package/in4073/in4073.h
+++ b/software_package/in4073/in4073.h
@@ -173,6 +173,10 @@ void send_telemetry_packet();
 uint8_t comm_link_failure;
 uint8_t abort_mission;
 
+// Processing offset from Keyboard 
+#define OFFSET_SCALING 10
+
+#define P_SCALING 5
 
 uint8_t proportional_controller_yaw;
 bool is_calibration_done;

--- a/software_package/in4073/modes/mode_2_manual.c
+++ b/software_package/in4073/modes/mode_2_manual.c
@@ -49,15 +49,15 @@ void mode_2_manual_RUN()
     js_yaw = ((axis[YAW]) * DT) >> BITSCALE;
     js_lift = (-(axis[LIFT] - 32767) >> 1) >> BITSCALE;
 
-    // a_roll = offset[ROLL] + js_roll;
-    // a_pitch = offset[PITCH] + js_pitch;
-    // a_yaw = offset[YAW] + js_yaw;
-    //a_lift = offset[LIFT] + js_lift;
+    a_roll = offset[ROLL] + js_roll;
+    a_pitch = offset[PITCH] + js_pitch;
+    a_yaw = offset[YAW] + js_yaw;
+    a_lift = offset[LIFT] + js_lift;
 
-    a_roll = ((offset[ROLL] + js_roll) < 0 ? 0 : offset[ROLL] + js_roll);
-    a_pitch = ((offset[PITCH] + js_pitch) < 0 ? 0 : offset[PITCH] + js_pitch);
-    a_yaw = ((offset[YAW] + js_yaw) < 0 ? 0 : offset[YAW] + js_yaw);
-    a_lift = ((offset[LIFT] + js_lift) < 0 ? 0 : offset[LIFT] + js_lift);
+    // a_roll = ((offset[ROLL] + js_roll) < 0 ? 0 : offset[ROLL] + js_roll);
+    // a_pitch = ((offset[PITCH] + js_pitch) < 0 ? 0 : offset[PITCH] + js_pitch);
+    // a_yaw = ((offset[YAW] + js_yaw) < 0 ? 0 : offset[YAW] + js_yaw);
+    // a_lift = ((offset[LIFT] + js_lift) < 0 ? 0 : offset[LIFT] + js_lift);
 
     oo1 = (a_lift + 2 * a_pitch - a_yaw);
 	oo2 = (a_lift - 2 * a_roll + a_yaw);

--- a/software_package/in4073/modes/mode_2_manual.c
+++ b/software_package/in4073/modes/mode_2_manual.c
@@ -49,10 +49,15 @@ void mode_2_manual_RUN()
     js_yaw = ((axis[YAW]) * DT) >> BITSCALE;
     js_lift = (-(axis[LIFT] - 32767) >> 1) >> BITSCALE;
 
-    a_roll = offset[ROLL] + js_roll;
-    a_pitch = offset[PITCH] + js_pitch;
-    a_yaw = offset[YAW] + js_yaw;
-    a_lift = offset[LIFT] + js_lift;
+    // a_roll = offset[ROLL] + js_roll;
+    // a_pitch = offset[PITCH] + js_pitch;
+    // a_yaw = offset[YAW] + js_yaw;
+    //a_lift = offset[LIFT] + js_lift;
+
+    a_roll = ((offset[ROLL] + js_roll) < 0 ? 0 : offset[ROLL] + js_roll);
+    a_pitch = ((offset[PITCH] + js_pitch) < 0 ? 0 : offset[PITCH] + js_pitch);
+    a_yaw = ((offset[YAW] + js_yaw) < 0 ? 0 : offset[YAW] + js_yaw);
+    a_lift = ((offset[LIFT] + js_lift) < 0 ? 0 : offset[LIFT] + js_lift);
 
     oo1 = (a_lift + 2 * a_pitch - a_yaw);
 	oo2 = (a_lift - 2 * a_roll + a_yaw);

--- a/software_package/in4073/modes/mode_2_manual.c
+++ b/software_package/in4073/modes/mode_2_manual.c
@@ -80,7 +80,14 @@ void mode_2_manual_RUN()
 	ae[2] = (oo3);
 	ae[3] = (oo4);
 
-
+    if(!oo1 && !oo2 && !oo3 && !oo4)
+    {
+        for(int i =0; i<3; i++)
+        {
+            offset[i] = 0;
+        }
+    }
+        
 
     update_motors();
 }

--- a/software_package/in4073/modes/mode_2_manual.c
+++ b/software_package/in4073/modes/mode_2_manual.c
@@ -80,14 +80,5 @@ void mode_2_manual_RUN()
 	ae[2] = (oo3);
 	ae[3] = (oo4);
 
-    if(!oo1 && !oo2 && !oo3 && !oo4)
-    {
-        for(int i =0; i<3; i++)
-        {
-            offset[i] = 0;
-        }
-    }
-        
-
     update_motors();
 }

--- a/software_package/in4073/modes/mode_2_manual.c
+++ b/software_package/in4073/modes/mode_2_manual.c
@@ -57,8 +57,7 @@ void mode_2_manual_RUN()
     // a_roll = ((offset[ROLL] + js_roll) < 0 ? 0 : offset[ROLL] + js_roll);
     // a_pitch = ((offset[PITCH] + js_pitch) < 0 ? 0 : offset[PITCH] + js_pitch);
     // a_yaw = ((offset[YAW] + js_yaw) < 0 ? 0 : offset[YAW] + js_yaw);
-    // a_lift = ((offset[LIFT] + js_lift) < 0 ? 0 : offset[LIFT] + js_lift);
-
+    
     oo1 = (a_lift + 2 * a_pitch - a_yaw);
 	oo2 = (a_lift - 2 * a_roll + a_yaw);
 	oo3 = (a_lift - 2 * a_pitch - a_yaw);
@@ -68,6 +67,13 @@ void mode_2_manual_RUN()
     oo2 = (oo2 < 200? MIN(a_lift, 200) : oo2);
     oo3 = (oo3 < 200 ? MIN(a_lift, 200) : oo3);
     oo4 = (oo4 < 200? MIN(a_lift, 200) : oo4);
+
+    //Preventing underflow by restricting engine speeds to be positive
+    oo1 = (oo1 < 0 ? 0 : oo1);
+    oo2 = (oo2 < 0? 0 : oo2);
+    oo3 = (oo3 < 0 ? 0 : oo3);
+    oo4 = (oo4 < 0? 0 : oo4);
+    
 
 	/* clip ooi as rotors only provide prositive thrust
 	 */

--- a/software_package/in4073/modes/mode_4_yaw.c
+++ b/software_package/in4073/modes/mode_4_yaw.c
@@ -60,7 +60,7 @@ void mode_4_yaw_RUN(void)
     //read sensor data
     // get_dmp_data(); // reads variable "sr"
     
-    int16_t setpoint_r = proportional_controller_yaw * js_yaw; // setpoint is angular rate
+    int16_t setpoint_r = js_yaw; // setpoint is angular rate
     js_yaw = proportional_controller_yaw * (setpoint_r - __SR);
 
     /* ##################################################

--- a/software_package/in4073/modes/mode_4_yaw.c
+++ b/software_package/in4073/modes/mode_4_yaw.c
@@ -88,6 +88,12 @@ void mode_4_yaw_RUN(void)
     oo3 = (oo3 < 200 ? MIN(a_lift, 200) : oo3);
     oo4 = (oo4 < 200? MIN(a_lift, 200) : oo4);
 
+    //Prevent underflow by restricting engine speeds to be positive
+    oo1 = (oo1 < 0 ? 0 : oo1);
+    oo2 = (oo2 < 0? 0 : oo2);
+    oo3 = (oo3 < 0 ? 0 : oo3);
+    oo4 = (oo4 < 0 ? 0 : oo4);
+
     if (oo1 > MAX_SPEED) oo1 = MAX_SPEED;
 	if (oo2 > MAX_SPEED) oo2 = MAX_SPEED;
 	if (oo3 > MAX_SPEED) oo3 = MAX_SPEED;

--- a/software_package/in4073/pc_terminal/packet_constants.h
+++ b/software_package/in4073/pc_terminal/packet_constants.h
@@ -1,5 +1,5 @@
 #define CONTROL_PACKET_SIZE 13
-#define TELEMETRY_PACKET_SIZE 17
+#define TELEMETRY_PACKET_SIZE 18
 
 #define START 0
 #define KEY 1
@@ -40,6 +40,7 @@
 // #define PRESSURE 27
 #define TIMESTAMP 12
 #define CRC_TELEMETRY 16
+#define P_VALUE 17
 
 #define MSBYTE(x) ((uint8_t) ((x & 0xff00) >> 8))
 

--- a/software_package/in4073/pc_terminal/packet_constants.h
+++ b/software_package/in4073/pc_terminal/packet_constants.h
@@ -39,8 +39,8 @@
 // #define TEMPERATURE 23
 // #define PRESSURE 27
 #define TIMESTAMP 12
-#define CRC_TELEMETRY 16
-#define P_VALUE 17
+#define P_VALUE 16
+#define CRC_TELEMETRY 17
 
 #define MSBYTE(x) ((uint8_t) ((x & 0xff00) >> 8))
 

--- a/software_package/in4073/pc_terminal/pc_terminal.c
+++ b/software_package/in4073/pc_terminal/pc_terminal.c
@@ -601,6 +601,9 @@ int main(int argc, char **argv)
 		{
 			control_packet[JOYBUTTON] |= (jsdat->button[j] == 1) << j; // 10 for not storing anything.
 		}
+		//If fire button is pressed send mode as panic (same as Esc key press behavior)
+		if(control_packet[JOYBUTTON] == 1)
+			control_packet[MODE] = 27;
 		
 		if ((d = term_getchar_nb()) != -1)
 		{

--- a/software_package/in4073/pc_terminal/telemetry_rx.c
+++ b/software_package/in4073/pc_terminal/telemetry_rx.c
@@ -29,6 +29,7 @@ uint16_t motor4 = 0;
 // int16_t sp, sq, sr = 0;
 // int32_t pressure = 0;
 uint16_t bat_volt;
+uint8_t p_value;
 int32_t timestamp = 0;
 
 void process_telemetry(uint8_t c)
@@ -79,7 +80,7 @@ void process_telemetry(uint8_t c)
             // sp = (packet_rx[SP]<<8)|packet_rx[SP+1];
             // sq = (packet_rx[SQ]<<8)|packet_rx[SQ+1];
             // sr = (packet_rx[SR]<<8)|packet_rx[SR+1];
-
+            p_value = packet_rx[P_VALUE]; 
             bat_volt = (packet_rx[BAT_VOLT]<<8)|packet_rx[BAT_VOLT+1];
             // pressure = (packet_rx[PRESSURE]<<24)|(packet_rx[PRESSURE + 1]<<16)|(packet_rx[PRESSURE + 2]<<8)|packet_rx[PRESSURE+3];
             timestamp = (packet_rx[TIMESTAMP]<<24)|(packet_rx[TIMESTAMP + 1]<<16)|(packet_rx[TIMESTAMP + 2]<<8)|packet_rx[TIMESTAMP+3];
@@ -87,6 +88,7 @@ void process_telemetry(uint8_t c)
             printf("Time |%6d|", timestamp);
             printf("Mode |%d|", packet_rx[MODE_DRONE]);
             printf("Motors |%3d %3d %3d %3d|", motor1,motor2,motor3,motor4);
+            printf("P |%d|", p_value);
             // printf("|%6d %6d %6d|",phi,theta,psi);
             // printf("|%6d %6d %6d|",sp,sq,sr);
             printf("Battery |%4d|\n",bat_volt);


### PR DESCRIPTION
- Adjust P value via keyboard keys 'u' and 'j' in steps of 1.
- Apply lift, roll, pitch and yaw offset to the drone from keyboard in steps of 1.
- Enabling of Abort mission action through joystick fire button press : results drone to enter panic mode.
- Offset clearing when joystick throttle is zero 
- Removed multiple lines of the same code to switch mode
- Restricted motors speeds to be positive to prevent underflow. Underflow occurs when the speed of all the engines is decreased beyond '0' by pressing 'z' (lift down) continuously.
- Adding one more byte in telemetry packet to display P value on PC. 