### PR TITLE
Decouple angle rate

### DIFF
--- a/software_package/in4073/control.c
+++ b/software_package/in4073/control.c
@@ -51,7 +51,7 @@ void run_filters_and_control()
 
 		js[ROLL]  = ((p_p1) * (P_SCALE*js[ROLL] /(p_p1) - __PHI ) - ((p_p2) * __SP))/P_SCALE;
 		// change sign of p_p2 ?
-		js[PITCH] = ((p_p1) * (P_SCALE*js[PITCH]/(p_p1) - __THETA) - ((p_p2) * __SQ))/P_SCALE;
+		js[PITCH] = ((p_p1) * (P_SCALE*js[PITCH]/(p_p1) - __THETA) + ((p_p2) * __SQ))/P_SCALE;
 		
 		// <divide by 8
 		// you can add telemetry here! Be careful with the number of bytes though.

--- a/software_package/in4073/control.c
+++ b/software_package/in4073/control.c
@@ -41,17 +41,17 @@ void run_filters_and_control()
 
 	if (mode == 4)
 	{
-		js[YAW] = (p_yaw * (js[YAW]/p_yaw - __SR))/P_SCALE;
+		js[YAW] = (p_yaw * (P_SCALE*js[YAW]/p_yaw - __SR))/P_SCALE;
 		// you can add telemetry here!
 	}
 
 	if (mode == 5)
 	{
-		js[YAW] = ((p_yaw) * (js[YAW]/(p_yaw) - __SR))/P_SCALE;
+		js[YAW] = ((p_yaw) * (P_SCALE*js[YAW]/(p_yaw) - __SR))/P_SCALE;
 
-		js[ROLL]  = ((p_p1) * (js[ROLL] /(p_p1) - __PHI ) - ((p_p2) * __SP))/P_SCALE;
+		js[ROLL]  = ((p_p1) * (P_SCALE*js[ROLL] /(p_p1) - __PHI ) - ((p_p2) * __SP))/P_SCALE;
 		// change sign of p_p2 ?
-		js[PITCH] = ((p_p1) * (js[PITCH]/(p_p1) - __THETA) - ((p_p2) * __SQ))/P_SCALE;
+		js[PITCH] = ((p_p1) * (P_SCALE*js[PITCH]/(p_p1) - __THETA) - ((p_p2) * __SQ))/P_SCALE;
 		
 		// <divide by 8
 		// you can add telemetry here! Be careful with the number of bytes though.

--- a/software_package/in4073/control.c
+++ b/software_package/in4073/control.c
@@ -48,17 +48,11 @@ void run_filters_and_control()
 	if (mode == 5)
 	{
 		js[YAW] = p_yaw * (js[YAW]/p_yaw - __SR);
-		js[ROLL] = p_p2 * (p_p1 * (js[ROLL]/(p_p1*p_p2) - __PHI) - __SP);
-		js[PITCH] = p_p2 * (p_p1 * (js[PITCH]/(p_p1*p_p2) - __THETA) - __SQ);
-		// you can add telemetry here!
+		js[ROLL] = p_p1 * (js[ROLL]/(p_p1) - __PHI) - (p_p2 * __SP);
+		js[PITCH] = p_p1 * (js[PITCH]/(p_p1) - __THETA) - (p_p2 * __SQ);
+		// you can add telemetry here! Be careful with the number of bytes though.
 		telemetry_packet[PHI] = MSBYTE(__PHI);
 		telemetry_packet[PHI+1] = LSBYTE(__PHI);
-		// WARNING WARNING WARNING
-		// 		be careful what you want to see as telemetry:
-		//		most current variables are on 4 BYTES now !!!
-		// 		Sensors and joystick raw values are still on 2 bytes though.
-		// telemetry_packet[SETPOINT_ROLL] = MSBYTE(axis[ROLL]);
-		// telemetry_packet[SETPOINT_ROLL+1] = LSBYTE(axis[ROLL]);
 	}
 
 

--- a/software_package/in4073/control.c
+++ b/software_package/in4073/control.c
@@ -47,9 +47,10 @@ void run_filters_and_control()
 
 	if (mode == 5)
 	{
-		js[YAW] = p_yaw * (js[YAW]/p_yaw - __SR);
-		js[ROLL] = (p_p1<<3) * (js[ROLL]/(p_p1) - __PHI) - ((p_p2<<3) * __SP);
-		js[PITCH] = (p_p1<<3) * (js[PITCH]/(p_p1) - __THETA) - ((p_p2<<3) * __SQ);
+		js[YAW] = (p_yaw>>3) * (js[YAW]/(p_yaw>>3) - __SR);
+		js[ROLL] = (p_p1>>3) * (js[ROLL]/(p_p1>>3) - __PHI) - ((p_p2>>3) * __SP);
+		js[PITCH] = (p_p1>>3) * (js[PITCH]/(p_p1>>3) - __THETA) - ((p_p2>>3) * __SQ);
+		// <divide by 8
 		// you can add telemetry here! Be careful with the number of bytes though.
 		telemetry_packet[PHI] = MSBYTE(__PHI);
 		telemetry_packet[PHI+1] = LSBYTE(__PHI);
@@ -73,6 +74,7 @@ void run_filters_and_control()
         // because coeff[ROLL] == coeff[PITCH] (I do this because of symmetry, makes sense)
         oo[i] = MAX(oo[i], 0);
         oo[i] = (oo[i] < MIN_SPEED*32 ? MIN(a[LIFT], MIN_SPEED*32) : oo[i]);
+		oo[i] = (a[LIFT] < MIN_SPEED*32 ? MIN(a[LIFT], oo[i]) : oo[i]);
         oo[i] = MIN(oo[i], MAX_SPEED*32);
         ae[i] = oo[i] / (32); // scale 0->32767 to 0->1023, but capped to 600 anyway.
         

--- a/software_package/in4073/control.c
+++ b/software_package/in4073/control.c
@@ -41,15 +41,18 @@ void run_filters_and_control()
 
 	if (mode == 4)
 	{
-		js[YAW] = p_yaw * (js[YAW]/p_yaw - __SR);
+		js[YAW] = (p_yaw * (js[YAW]/p_yaw - __SR))/P_SCALE;
 		// you can add telemetry here!
 	}
 
 	if (mode == 5)
 	{
-		js[YAW] = (p_yaw>>3) * (js[YAW]/(p_yaw>>3) - __SR);
-		js[ROLL] = (p_p1>>3) * (js[ROLL]/(p_p1>>3) - __PHI) - ((p_p2>>3) * __SP);
-		js[PITCH] = (p_p1>>3) * (js[PITCH]/(p_p1>>3) - __THETA) - ((p_p2>>3) * __SQ);
+		js[YAW] = ((p_yaw) * (js[YAW]/(p_yaw) - __SR))/P_SCALE;
+
+		js[ROLL]  = ((p_p1) * (js[ROLL] /(p_p1) - __PHI ) - ((p_p2) * __SP))/P_SCALE;
+		// change sign of p_p2 ?
+		js[PITCH] = ((p_p1) * (js[PITCH]/(p_p1) - __THETA) - ((p_p2) * __SQ))/P_SCALE;
+		
 		// <divide by 8
 		// you can add telemetry here! Be careful with the number of bytes though.
 		telemetry_packet[PHI] = MSBYTE(__PHI);

--- a/software_package/in4073/control.c
+++ b/software_package/in4073/control.c
@@ -48,8 +48,8 @@ void run_filters_and_control()
 	if (mode == 5)
 	{
 		js[YAW] = p_yaw * (js[YAW]/p_yaw - __SR);
-		js[ROLL] = p_p1 * (js[ROLL]/(p_p1) - __PHI) - (p_p2 * __SP);
-		js[PITCH] = p_p1 * (js[PITCH]/(p_p1) - __THETA) - (p_p2 * __SQ);
+		js[ROLL] = (p_p1<<3) * (js[ROLL]/(p_p1) - __PHI) - ((p_p2<<3) * __SP);
+		js[PITCH] = (p_p1<<3) * (js[PITCH]/(p_p1) - __THETA) - ((p_p2<<3) * __SQ);
 		// you can add telemetry here! Be careful with the number of bytes though.
 		telemetry_packet[PHI] = MSBYTE(__PHI);
 		telemetry_packet[PHI+1] = LSBYTE(__PHI);

--- a/software_package/in4073/in4073.c
+++ b/software_package/in4073/in4073.c
@@ -78,17 +78,17 @@ void store_key(uint8_t *val)
 	switch(keyboard_key)
 	{
     /* Keys for P controllers adjust*/
-		case 'u': p_yaw += P_SCALING;
+		case 'u': p_yaw = MIN(p_yaw+1, 254);
 				  break;
-		case 'j': p_yaw = (p_yaw > P_SCALING ? p_yaw-P_SCALING : 1);
+		case 'j': p_yaw = MAX(p_yaw-1, 1);
 			      break;
-		case 'i': p_p1 += P_SCALING;
-				  break;	
-		case 'k': p_p1 = (p_p1 > P_SCALING ? p_p1 - P_SCALING : 1);
+		case 'i': p_p1 = MIN(p_p1+1, 254);
+				  break;
+		case 'k': p_p1 = MAX(p_p1-1, 1);
 			      break;
-		case 'o': p_p2 += P_SCALING;
+		case 'o': p_p2 = MIN(p_p2+1, 254);
 				  break;	
-		case 'l': p_p2 = (p_p2 > P_SCALING ? p_p2 - P_SCALING : 1);
+		case 'l': p_p2 = MAX(p_p2-1, 1);
 			      break;
       
       

--- a/software_package/in4073/modes/mode_4_yaw.c
+++ b/software_package/in4073/modes/mode_4_yaw.c
@@ -4,6 +4,8 @@ Author:Yuhao Xuan
 */
 #include "in4073.h"
 #include "switch_mode.h"
+#include "modes_flight.h"
+
 
 
 
@@ -26,9 +28,6 @@ char mode_4_yaw_CANENTER(uint8_t source)
 }
 void mode_4_yaw_INIT()
 {
-
-    for (int i = 0; i < 4; i++) 
-        flight_coeffs[i] = 1;
     
     // coefficients determined empirically. They seem more or less ok.
     flight_coeffs[ROLL] = 9;
@@ -37,7 +36,7 @@ void mode_4_yaw_INIT()
     flight_coeffs[YAW] = 2*flight_coeffs[ROLL];
 
     // initialize the global variable for the controller.
-    p_yaw = 1;
+    p_yaw = P_SCALE;
 }
 
 void mode_4_yaw_QUIT()

--- a/software_package/in4073/modes/mode_5_full.c
+++ b/software_package/in4073/modes/mode_5_full.c
@@ -36,9 +36,9 @@ void mode_5_full_INIT()
     flight_coeffs[YAW] = 2*flight_coeffs[ROLL];
 
     // initialize the global variable for the controller.
-    p_yaw = 1;
-    p_p1 = 1;
-    p_p2 = 1;
+    p_yaw = 8;
+    p_p1 = 8;
+    p_p2 = 8;
 }
 
 void mode_5_full_QUIT()

--- a/software_package/in4073/modes/mode_5_full.c
+++ b/software_package/in4073/modes/mode_5_full.c
@@ -4,6 +4,7 @@ Author:Yuhao Xuan, Jonathan Levy
 */
 #include "in4073.h"
 #include "switch_mode.h"
+#include "modes_flight.h"
 
 
 char mode_5_full_CANLEAVE(uint8_t target)
@@ -36,9 +37,9 @@ void mode_5_full_INIT()
     flight_coeffs[YAW] = 2*flight_coeffs[ROLL];
 
     // initialize the global variable for the controller.
-    p_yaw = 8;
-    p_p1 = 8;
-    p_p2 = 8;
+    p_yaw = P_SCALE;
+    p_p1 = P_SCALE;
+    p_p2 = P_SCALE;
 }
 
 void mode_5_full_QUIT()

--- a/software_package/in4073/modes/modes_flight.h
+++ b/software_package/in4073/modes/modes_flight.h
@@ -5,7 +5,8 @@
 #define MIN(a,b) (a < b ? a : b)
 #define MAX(a,b) (a > b ? a : b)
 
-
+// this allows for better precision for controller tuning
+#define P_SCALE (16)
 
 // define easy-to-use macros for sensor - offset
 #define __SAX    (sax - sax_offset)


### PR DESCRIPTION
Multiple important (and GOOD !) changes up here:

- The equation for control decouples the ANGLE (P1) and the RATE (P2). Move them to your heart's content !
- The precision should be increased with the division by P_SCALE, which is fixed at 16 at the moment. It's not possible to put a Pi to zero, but putting it to the minimum value (meaning 1/16th) should be enough for not feeling it when tuning by hand.
**WARNING: Because of the division by 16, and the fact that, unlike p_yaw, p_p1 and p_p2 are on uint8_t, they can't go higher than 254, so 256/16 = 16 in real life! To fix that, we would have to change them to uint16_t, so changing the telemetry to handle 2 bytes. That should be added in a next branch.**
- The pitch rate was not given the good sign, it is fixed now.
