### PR TITLE
adjusted telemtry for p1 and p2, removed phi print and some cleanup

### DIFF
--- a/software_package/in4073/control.c
+++ b/software_package/in4073/control.c
@@ -55,8 +55,6 @@ void run_filters_and_control()
 		
 		// <divide by 8
 		// you can add telemetry here! Be careful with the number of bytes though.
-		telemetry_packet[PHI] = MSBYTE(__PHI);
-		telemetry_packet[PHI+1] = LSBYTE(__PHI);
 	}
 
 

--- a/software_package/in4073/in4073.c
+++ b/software_package/in4073/in4073.c
@@ -78,15 +78,15 @@ void store_key(uint8_t *val)
 	switch(keyboard_key)
 	{
     /* Keys for P controllers adjust*/
-		case 'u': p_yaw = MIN(p_yaw+1, 254);
+		case 'u': p_yaw = MIN(p_yaw+1, 65534);
 				  break;
 		case 'j': p_yaw = MAX(p_yaw-1, 1);
 			      break;
-		case 'i': p_p1 = MIN(p_p1+1, 254);
+		case 'i': p_p1 = MIN(p_p1+1, 65534);
 				  break;
 		case 'k': p_p1 = MAX(p_p1-1, 1);
 			      break;
-		case 'o': p_p2 = MIN(p_p2+1, 254);
+		case 'o': p_p2 = MIN(p_p2+1, 65534);
 				  break;	
 		case 'l': p_p2 = MAX(p_p2-1, 1);
 			      break;
@@ -125,29 +125,11 @@ void store_key(uint8_t *val)
 	}
 	telemetry_packet[P_YAW] = MSBYTE(p_yaw);
 	telemetry_packet[P_YAW+1] = LSBYTE(p_yaw);
-	telemetry_packet[P1] = p_p1;
-	telemetry_packet[P2] = p_p2;
+	telemetry_packet[P1] = MSBYTE(p_p1);
+	telemetry_packet[P1+1] = LSBYTE(p_p1);
+	telemetry_packet[P2] = MSBYTE(p_p2);
+	telemetry_packet[P2+1] = LSBYTE(p_p2);
 }
-	
-	// switch(keyboard_key)
-	// {
-	// 	case 97: offset[LIFT] = offset[LIFT] + 10; //lift up
-	// 			 break;
-	// 	case 122: offset[LIFT] = offset[LIFT] - 10; //lift down
-	// 			 break;
-	// 	case 42: offset[PITCH] = offset[PITCH] - 10; //pitch down
-	// 			 break;
-	// 	case 43: offset[LIFT] = offset[ROLL] - 10; //roll down
-	// 			 break;
-	// 	case 44: offset[LIFT] = offset[PITCH] + 10; //pitch up
-	// 			 break;
-	// 	case 45: offset[PITCH] = offset[ROLL] + 10; //roll up
-	// 			 break;
-	// 	case 113: offset[YAW] = offset[YAW] - 10; //yaw down
-	// 			 break;
-	// 	case 119: offset[YAW] = offset[YAW] + 10; //yaw up
-	// 			 break; 
-	// }
 
 
 void store_mode(uint8_t *val)

--- a/software_package/in4073/pc_terminal/packet_constants.h
+++ b/software_package/in4073/pc_terminal/packet_constants.h
@@ -5,10 +5,6 @@
 #define KEY 1
 #define MODE 2
 #define JOYBUTTON 3
-// #define AXISTHROTTLE 4
-// #define AXISROLL 6
-// #define AXISPITCH 8
-// #define AXISYAW 10
 #define AXISROLL 4
 #define AXISPITCH 6
 #define AXISYAW 8
@@ -25,25 +21,12 @@
 #define ROTOR2 3
 #define ROTOR3 5
 #define ROTOR4 7
-
 #define MODE_DRONE 9
-
-// #define PHI 9
-// #define THETA 11
-// #define PSI 13
-// #define SP 15
-// #define SQ 17
-// #define SR 19
-
 #define BAT_VOLT 10
-// #define TEMPERATURE 23
-// #define PRESSURE 27
 #define TIMESTAMP 12
 #define P_YAW 16
 #define P1 18
-#define P2 19
-#define PHI 20
-//#define SETPOINT_ROLL 22
+#define P2 20
 #define CRC_TELEMETRY 22
 
 #define MSBYTE(x) ((uint8_t) ((x & 0xff00) >> 8))

--- a/software_package/in4073/pc_terminal/telemetry_rx.c
+++ b/software_package/in4073/pc_terminal/telemetry_rx.c
@@ -31,9 +31,9 @@ uint16_t motor4 = 0;
 uint16_t bat_volt;
 
 uint16_t p_value;
-uint8_t p1_value;
-uint8_t p2_value;
-int16_t phi;
+uint16_t p1_value;
+uint16_t p2_value;
+//int16_t phi;
 
 
 int32_t timestamp = 0;
@@ -79,23 +79,12 @@ void process_telemetry(uint8_t c)
             motor3 = (packet_rx[ROTOR3]<<8)|packet_rx[ROTOR3+1];
             motor4 = (packet_rx[ROTOR4]<<8)|packet_rx[ROTOR4+1];
 
-            // phi = (packet_rx[PHI]<<8)|packet_rx[PHI+1];
-            // theta = (packet_rx[THETA]<<8)|packet_rx[THETA+1];
-            // psi = (packet_rx[PSI]<<8)|packet_rx[PSI+1];
-
-            // sp = (packet_rx[SP]<<8)|packet_rx[SP+1];
-            // sq = (packet_rx[SQ]<<8)|packet_rx[SQ+1];
-            // sr = (packet_rx[SR]<<8)|packet_rx[SR+1];
             p_value = (packet_rx[P_YAW]<<8)|packet_rx[P_YAW+1];
 
-            p1_value = packet_rx[P1];
-            p2_value = packet_rx[P2];
-
-            phi = (packet_rx[PHI]<<8)|packet_rx[PHI+1];
-            //setpoint_roll = (packet_rx[SETPOINT_ROLL]<<8)|packet_rx[SETPOINT_ROLL+1];
+            p1_value = packet_rx[P1]<<8|packet_rx[P1+1];
+            p2_value = packet_rx[P2]<<8|packet_rx[P2+1];
 
             bat_volt = (packet_rx[BAT_VOLT]<<8)|packet_rx[BAT_VOLT+1];
-            // pressure = (packet_rx[PRESSURE]<<24)|(packet_rx[PRESSURE + 1]<<16)|(packet_rx[PRESSURE + 2]<<8)|packet_rx[PRESSURE+3];
             timestamp = (packet_rx[TIMESTAMP]<<24)|(packet_rx[TIMESTAMP + 1]<<16)|(packet_rx[TIMESTAMP + 2]<<8)|packet_rx[TIMESTAMP+3];
 
             printf("Time |%6d|", timestamp);
@@ -104,10 +93,7 @@ void process_telemetry(uint8_t c)
             printf("P |%d|", p_value);
             printf("P1 |%d| ", p1_value);
             printf("P2 |%d|", p2_value);
-            printf("phi |%d|", phi);
-            //printf("setpoint_roll |%d|", setpoint_roll);
           
-
             // printf("|%6d %6d %6d|",phi,theta,psi);
             // printf("|%6d %6d %6d|",sp,sq,sr);
             printf("Battery |%4d|\n",bat_volt);


### PR DESCRIPTION
- Adjusted telemetry for P1, P2 which are now uint16_t
- P1 and P2 can now be increased to 65534 instead of 254
- Removed phi from telemetry data
- Some cleanup
- Basic test done.